### PR TITLE
Update 05_notification.rb

### DIFF
--- a/examples/05_notification.rb
+++ b/examples/05_notification.rb
@@ -15,9 +15,9 @@ nf.timeout = 3000
 nf.urgency = :critical
 
 # Show a button 'Test' in the notification, with a callback function.
-nf.add_action "test", "Test", Proc.new { |obj, action, user_data|
+nf.add_action("test", "Test") { |obj, action, user_data|
   puts "Action #{action} clicked."
-}, nil, nil
+}
 
 # In this case, we want the program to end once the notification is gone,
 # but not before.


### PR DESCRIPTION
Notify::Notification#add_action spawns an error when run as per the example with 5 arguments ("test", "Test", BLOCK, nil nil).
After some debugging through pry, I found that it only takes 2 arguments + a block as callback. I updated the example script so that it works now.