### PR TITLE
Override events methods to take EventMask values

### DIFF
--- a/lib/gir_ffi-gtk/widget.rb
+++ b/lib/gir_ffi-gtk/widget.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+module GirFFIGtk
+  # Overrides for GtkWidget methods
+  module WidgetOverrides
+    def add_events(events)
+      super Gdk::EventMask.to_int events
+    end
+
+    def get_events
+      Gdk::EventMask.from_native super
+    end
+
+    def set_events(events)
+      super Gdk::EventMask.to_int events
+    end
+  end
+end
+
+Gtk.load_class :Widget
+
+Gtk::Widget.setup_instance_method! :add_events
+Gtk::Widget.setup_instance_method! :get_events
+Gtk::Widget.setup_instance_method! :set_events
+Gtk::Widget.prepend GirFFIGtk::WidgetOverrides

--- a/lib/gir_ffi-gtk2.rb
+++ b/lib/gir_ffi-gtk2.rb
@@ -18,6 +18,7 @@ require 'gir_ffi-gtk/message_dialog'
 require 'gir_ffi-gtk/tree_path'
 require 'gir_ffi-gtk/tree_store'
 require 'gir_ffi-gtk/tree_view_column'
+require 'gir_ffi-gtk/widget'
 
 require 'gir_ffi-gtk/gtk2/list_store'
 require 'gir_ffi-gtk/gtk2/radio_action'

--- a/lib/gir_ffi-gtk3.rb
+++ b/lib/gir_ffi-gtk3.rb
@@ -18,6 +18,7 @@ require 'gir_ffi-gtk/message_dialog'
 require 'gir_ffi-gtk/tree_path'
 require 'gir_ffi-gtk/tree_store'
 require 'gir_ffi-gtk/tree_view_column'
+require 'gir_ffi-gtk/widget'
 
 require 'gir_ffi-gtk/gtk3/button'
 require 'gir_ffi-gtk/gtk3/target_entry'

--- a/test/gir_ffi-gtk/widget_test.rb
+++ b/test/gir_ffi-gtk/widget_test.rb
@@ -1,0 +1,103 @@
+require 'test_helper'
+
+describe Gtk::Widget do
+  describe '#add_events' do
+    let(:widget) { Gtk::EventBox.new }
+    let(:expected_native) do
+      Gdk::EventMask.to_int(focus_change_mask: true,
+                            button_press_mask: true)
+    end
+
+    before do
+      ev_int = Gdk::EventMask.to_int :focus_change_mask
+      widget.set_events ev_int
+    end
+
+    it 'works when called with a bitmask hash' do
+      widget.add_events button_press_mask: true
+      ev = widget.get_events
+      Gdk::EventMask.to_int(ev).must_equal expected_native
+    end
+
+    it 'works when called with a symbol' do
+      widget.add_events :button_press_mask
+      ev = widget.get_events
+      Gdk::EventMask.to_int(ev).must_equal expected_native
+    end
+
+    it 'works when called with an int' do
+      ev_int = Gdk::EventMask.to_int :button_press_mask
+      widget.add_events ev_int
+      ev = widget.get_events
+      Gdk::EventMask.to_int(ev).must_equal expected_native
+    end
+  end
+
+  describe '#get_events' do
+    let(:widget) { Gtk::EventBox.new }
+
+    it 'returns a bitmap hash' do
+      widget.set_events focus_change_mask: true
+      ev = widget.get_events
+      ev.must_equal focus_change_mask: true
+    end
+  end
+
+  describe '#set_events' do
+    let(:widget) { Gtk::EventBox.new }
+    let(:expected_native) { Gdk::EventMask.to_int(focus_change_mask: true) }
+
+    it 'works when called with a bitmask hash' do
+      widget.set_events focus_change_mask: true
+      ev = widget.get_events
+      Gdk::EventMask.to_int(ev).must_equal expected_native
+    end
+
+    it 'works when called with a symbol' do
+      widget.set_events :focus_change_mask
+      ev = widget.get_events
+      Gdk::EventMask.to_int(ev).must_equal expected_native
+    end
+
+    it 'works when called with an int' do
+      ev_int = Gdk::EventMask.to_int :focus_change_mask
+      widget.set_events ev_int
+      ev = widget.get_events
+      Gdk::EventMask.to_int(ev).must_equal expected_native
+    end
+  end
+
+  describe '#events' do
+    let(:widget) { Gtk::EventBox.new }
+
+    it 'returns a bitmap hash' do
+      widget.set_events focus_change_mask: true
+      ev = widget.events
+      ev.must_equal focus_change_mask: true
+    end
+  end
+
+  describe '#events=' do
+    let(:widget) { Gtk::EventBox.new }
+    let(:expected_native) { Gdk::EventMask.to_int(focus_change_mask: true) }
+
+    it 'works when called with a bitmask hash' do
+      widget.events = { focus_change_mask: true }
+      ev = widget.get_events
+      Gdk::EventMask.to_int(ev).must_equal expected_native
+    end
+
+    it 'works when called with a symbol' do
+      widget.events = :focus_change_mask
+      ev = widget.get_events
+      Gdk::EventMask.to_int(ev).must_equal expected_native
+    end
+
+    it 'works when called with an int' do
+      ev_int = Gdk::EventMask.to_int :focus_change_mask
+      widget.events = ev_int
+      ev = widget.get_events
+      Gdk::EventMask.to_int(ev).must_equal expected_native
+    end
+  end
+end


### PR DESCRIPTION
These methods are documented to work with `Gdk::EventMask` values, but annotated as `int`s. It is very inconvenient to manually convert this every time, so do this automatically.

Fixes #30.