### PR TITLE
Run build on Travis CI with its xvfb service

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,15 @@
-sudo: required
-dist: trusty
 language: ruby
 
+dist: xenial
+
+services:
+  - xvfb
+
 before_install:
-  - sudo apt-get -qq update
+  - sudo apt-get update
   - sudo apt-get install -y libgirepository1.0-dev gobject-introspection
-  - sudo apt-get install -y gir1.2-gtk-3.0 gir1.2-gtk-2.0
-  - gem update --system
+  - sudo apt-get install -y gir1.2-gtk-3.0
+  - sudo apt-get install -y gir1.2-gtk-2.0
 
 rvm:
   - 2.4
@@ -20,12 +23,6 @@ matrix:
   allow_failures:
     - rvm: jruby-head
     - rvm: ruby-head
-
-before_script:
-  - "export DISPLAY=:99.0"
-  - "sh -e /etc/init.d/xvfb start"
-
-script: "DISPLAY=:99.0 bundle exec rake test"
 
 branches:
   only:


### PR DESCRIPTION
With the Xenial distribution, Travis CI provices an xvfb service so xvfb-run is no longer needed.