### PR TITLE
Bump RuboCop dependency versions and update configuration

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -11,6 +11,10 @@ AllCops:
   NewCops: enable
   TargetRubyVersion: 2.7
 
+# Put development dependencies in the gemspec so rubygems.org knows about them
+Gemspec/DevelopmentDependencies:
+  EnforcedStyle: gemspec
+
 # Make BeginEndAlignment behavior match EndAlignment
 Layout/BeginEndAlignment:
   EnforcedStyleAlignWith: begin

--- a/gir_ffi-gtk.gemspec
+++ b/gir_ffi-gtk.gemspec
@@ -27,9 +27,9 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "minitest", "~> 5.12"
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "rake-manifest", "~> 0.2.0"
-  spec.add_development_dependency "rubocop", "~> 1.25"
+  spec.add_development_dependency "rubocop", "~> 1.52"
   spec.add_development_dependency "rubocop-minitest", "~> 0.31.0"
-  spec.add_development_dependency "rubocop-packaging", "~> 0.5.0"
-  spec.add_development_dependency "rubocop-performance", "~> 1.13"
+  spec.add_development_dependency "rubocop-packaging", "~> 0.5.2"
+  spec.add_development_dependency "rubocop-performance", "~> 1.18"
   spec.add_development_dependency "simplecov", "~> 0.22.0"
 end


### PR DESCRIPTION
- Bump versions for rubocop dependencies
- Require development dependencies to be in the gemspec
