### PR TITLE
Add rubocop-rake and fix offenses

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -6,6 +6,7 @@ require:
   - rubocop-minitest
   - rubocop-packaging
   - rubocop-performance
+  - rubocop-rake
 
 AllCops:
   NewCops: enable

--- a/Rakefile
+++ b/Rakefile
@@ -12,6 +12,6 @@ Rake::Manifest::Task.new do |t|
   t.patterns = ["lib/**/*.rb", "*.md", "COPYING.LIB"]
 end
 
-task build: "manifest:check"
+task build: ["manifest:check"]
 
 task default: [:test, "manifest:check"]

--- a/gir_ffi-gtk.gemspec
+++ b/gir_ffi-gtk.gemspec
@@ -31,5 +31,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rubocop-minitest", "~> 0.31.0"
   spec.add_development_dependency "rubocop-packaging", "~> 0.5.2"
   spec.add_development_dependency "rubocop-performance", "~> 1.18"
+  spec.add_development_dependency "rubocop-rake", "~> 0.6.0"
   spec.add_development_dependency "simplecov", "~> 0.22.0"
 end

--- a/tasks/test.rake
+++ b/tasks/test.rake
@@ -4,27 +4,17 @@ require "rake/testtask"
 
 namespace :test do
   Rake::TestTask.new(:gtk3) do |t|
-    t.libs = ["lib"]
+    t.libs << "test"
     t.test_files = FileList["test/**/*_test.rb"]
-    t.ruby_opts += ["-w", "-Itest"]
+    t.ruby_opts += ["-rgir_ffi-gtk3"]
   end
 
   Rake::TestTask.new(:gtk2) do |t|
-    t.libs = ["lib"]
+    t.libs << "test"
     t.test_files = FileList["test/**/*_test.rb"]
-    t.ruby_opts += ["-w", "-Itest"]
-  end
-
-  task gtk2: :set_gtk_version_2
-
-  task :set_gtk_version_2 do
-    ENV["GTK_VERSION"] = "2"
-  end
-
-  task :sleep do
-    sleep 1
+    t.ruby_opts += ["-rgir_ffi-gtk2"]
   end
 end
 
 desc "Run unit tests"
-task test: ["test:gtk3", "test:sleep", "test:gtk2"]
+task test: ["test:gtk3", "test:gtk2"]

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -11,11 +11,15 @@ require "minitest/autorun"
 
 Thread.abort_on_exception = true
 
-if ENV["GTK_VERSION"] == "2"
-  require "gir_ffi-gtk2"
-else
-  require "gir_ffi-gtk3"
+unless defined? Gtk
+  if ENV["GTK_VERSION"] == "2"
+    require "gir_ffi-gtk2"
+  else
+    require "gir_ffi-gtk3"
+  end
 end
+
+warn "Testing with Gtk version #{Gtk::MAJOR_VERSION}.#{Gtk::MINOR_VERSION}"
 
 module BaseTestExtensions
   def assert_nothing_raised


### PR DESCRIPTION
- Add rubocop-rake
- Fix Rake/Desc offense in Rakefile
- Avoid use of ENV variables to select Gtk version in test tasks
