### PR TITLE
Use correct function signature for gtk_tree_path_new_from_indices

### DIFF
--- a/lib/gir_ffi-gtk/tree_path.rb
+++ b/lib/gir_ffi-gtk/tree_path.rb
@@ -5,7 +5,7 @@ module Gtk
   # Add non-introspected function to Gtk::Lib
   module Lib
     if Gtk::MAJOR_VERSION == 2 || Gtk::MAJOR_VERSION == 3 && Gtk::MINOR_VERSION < 12
-      attach_function :gtk_tree_path_new_from_indices, [:varargs], :pointer
+      attach_function :gtk_tree_path_new_from_indices, [:int, :varargs], :pointer
     end
   end
 
@@ -19,8 +19,9 @@ module Gtk
       end
 
       def initialize_from_indices(indices)
-        args = indices.flat_map { |index| [:int, index] }
-        ptr = Gtk::Lib.gtk_tree_path_new_from_indices(*args, :int, -1)
+        head, *rest = *indices
+        args = rest.flat_map { |index| [:int, index] }
+        ptr = Gtk::Lib.gtk_tree_path_new_from_indices(head, *args, :int, -1)
         store_pointer ptr
       end
     end


### PR DESCRIPTION
The first argument of this function is a fixed argument. See https://docs.gtk.org/gtk3/ctor.TreePath.new_from_indices.html.

This change prevents an assertion failure in `ffi_prep_cif_core` in libffi when it is compiled with certain options: It requires variadic functions to have at least one fixed argument.
