### PR TITLE
Replace soft-deprecated runtime dependency specification

### DIFF
--- a/gir_ffi-gtk.gemspec
+++ b/gir_ffi-gtk.gemspec
@@ -22,7 +22,7 @@ Gem::Specification.new do |spec|
   spec.files = File.read("Manifest.txt").split
   spec.require_paths = ["lib"]
 
-  spec.add_runtime_dependency "gir_ffi", "~> 0.17.0"
+  spec.add_dependency "gir_ffi", "~> 0.17.0"
 
   spec.add_development_dependency "minitest", "~> 5.12"
   spec.add_development_dependency "minitest-focus", "~> 1.4"


### PR DESCRIPTION
Using add_runtime_dependency is soft-deprecated and now flagged by RuboCop.
