### PR TITLE
Update RuboCop configuration and handle new offenses

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,7 +2,7 @@ inherit_mode:
   merge:
     - Exclude
 
-require:
+plugins:
   - rubocop-minitest
   - rubocop-packaging
   - rubocop-performance

--- a/examples/10_completion_provider.rb
+++ b/examples/10_completion_provider.rb
@@ -20,7 +20,9 @@ class TestProvider < GObject::Object
     1
   end
 
-  def match(_context)
+  # TODO: Allow method name and vfunc name to be different, so this method can
+  # be renamed to #match?
+  def match(_context) # rubocop:disable Naming/PredicateMethod
     true
   end
 

--- a/gir_ffi-gtk.gemspec
+++ b/gir_ffi-gtk.gemspec
@@ -29,10 +29,10 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "minitest-focus", "~> 1.4"
   spec.add_development_dependency "rake", "~> 13.0"
   spec.add_development_dependency "rake-manifest", "~> 0.2.0"
-  spec.add_development_dependency "rubocop", "~> 1.52"
+  spec.add_development_dependency "rubocop", "~> 1.76"
   spec.add_development_dependency "rubocop-minitest", "~> 0.38.0"
   spec.add_development_dependency "rubocop-packaging", "~> 0.6.0"
-  spec.add_development_dependency "rubocop-performance", "~> 1.18"
+  spec.add_development_dependency "rubocop-performance", "~> 1.25"
   spec.add_development_dependency "rubocop-rake", "~> 0.7.1"
   spec.add_development_dependency "simplecov", "~> 0.22.0"
 end

--- a/test/callback_exceptions_test.rb
+++ b/test/callback_exceptions_test.rb
@@ -28,6 +28,7 @@ describe "An exception in a callback" do
         end
         # Guard against runaway loop
         @guard = GLib.timeout_add(GLib::PRIORITY_DEFAULT, 1000) { Gtk.main_quit }
+
         _(-> { Gtk.main }).must_raise CallbackTestException
       end
 
@@ -45,6 +46,7 @@ describe "An exception in a callback" do
         end
         # Guard against runaway loop
         @guard = GLib.timeout_add(GLib::PRIORITY_DEFAULT, 1000) { Gtk.main_quit }
+
         _(-> { Gtk.main }).must_raise CallbackTestException
       end
 

--- a/test/gir_ffi-gtk/action_test.rb
+++ b/test/gir_ffi-gtk/action_test.rb
@@ -8,11 +8,13 @@ describe Gtk::Action do
   describe "#create_icon" do
     it "works when called with a symbol" do
       result = action.create_icon :dialog
+
       _(result).must_be_instance_of Gtk::Image
     end
 
     it "works when called with an integer" do
       result = action.create_icon 4
+
       _(result).must_be_instance_of Gtk::Image
     end
   end

--- a/test/gir_ffi-gtk/builder_test.rb
+++ b/test/gir_ffi-gtk/builder_test.rb
@@ -43,6 +43,7 @@ describe Gtk::Builder do
       end
       button = builder.get_object("foo")
       GObject.signal_emit button, "clicked"
+
       _(name).must_equal "on_button_clicked"
     end
 
@@ -65,6 +66,7 @@ describe Gtk::Builder do
         end
         button = builder.get_object("foo")
         GObject.signal_emit button, "clicked"
+
         _(name).must_equal "handler_after"
       end
     end

--- a/test/gir_ffi-gtk/button_test.rb
+++ b/test/gir_ffi-gtk/button_test.rb
@@ -10,11 +10,13 @@ describe Gtk::Button do
 
     it "works when called with a symbol" do
       result = Gtk::Button.new_from_icon_name("hi", :dialog)
+
       _(result).must_be_instance_of Gtk::Button
     end
 
     it "works when called with an integer" do
       result = Gtk::Button.new_from_icon_name("hi", 4)
+
       _(result).must_be_instance_of Gtk::Button
     end
   end

--- a/test/gir_ffi-gtk/container_test.rb
+++ b/test/gir_ffi-gtk/container_test.rb
@@ -24,11 +24,13 @@ describe Gtk::Container do
     it "fetches the given child property" do
       container.add widget
       container.child_set_property(widget, "left-attach", 1)
+
       _(container.child_get_property(widget, "left-attach")).must_equal 1
     end
 
     it "raises an ArgumentError for unknown properties" do
       container.add widget
+
       _(proc { container.child_get_property(widget, "foobar") }).must_raise ArgumentError
     end
   end

--- a/test/gir_ffi-gtk/dialog_test.rb
+++ b/test/gir_ffi-gtk/dialog_test.rb
@@ -6,8 +6,10 @@ describe Gtk::Dialog do
   describe ".new_with_buttons" do
     it "creates a Gtk::Dialog with the right title and buttons" do
       dialog = Gtk::Dialog.new_with_buttons "Foo", nil, :modal, [["Bar", :yes]]
+
       _(dialog.title).must_equal "Foo"
       button = dialog.action_area.children.first
+
       _(button.label).must_equal "Bar"
       _(dialog.response_for_widget(button)).must_equal Gtk::ResponseType.to_int(:yes)
     end

--- a/test/gir_ffi-gtk/file_chooser_dialog_test.rb
+++ b/test/gir_ffi-gtk/file_chooser_dialog_test.rb
@@ -6,6 +6,7 @@ describe Gtk::FileChooserDialog do
   describe ".new" do
     it "creates a Gtk::FileChooserDialog with the right attributes" do
       dialog = Gtk::FileChooserDialog.new "Foo", nil, :save, [["Bar", :yes]]
+
       _(dialog.title).must_equal "Foo"
       _(dialog.action).must_equal :save
       button =
@@ -14,6 +15,7 @@ describe Gtk::FileChooserDialog do
         else
           dialog.action_area.children.to_a.last
         end
+
       _(button.label).must_equal "Bar"
       _(dialog.response_for_widget(button)).must_equal Gtk::ResponseType.to_int(:yes)
     end

--- a/test/gir_ffi-gtk/image_test.rb
+++ b/test/gir_ffi-gtk/image_test.rb
@@ -6,11 +6,13 @@ describe Gtk::Image do
   describe ".new_from_icon_name" do
     it "works when called with a symbol" do
       result = Gtk::Image.new_from_icon_name("hi", :dialog)
+
       _(result).must_be_instance_of Gtk::Image
     end
 
     it "works when called with an integer" do
       result = Gtk::Image.new_from_icon_name("hi", 4)
+
       _(result).must_be_instance_of Gtk::Image
     end
   end
@@ -19,11 +21,13 @@ describe Gtk::Image do
     let(:gicon) { Gio::ThemedIcon.new("hi") }
     it "works when called with a symbol" do
       result = Gtk::Image.new_from_gicon(gicon, :dialog)
+
       _(result).must_be_instance_of Gtk::Image
     end
 
     it "works when called with an integer" do
       result = Gtk::Image.new_from_gicon(gicon, 4)
+
       _(result).must_be_instance_of Gtk::Image
     end
   end
@@ -34,11 +38,13 @@ describe Gtk::Image do
 
     it "works when called with a symbol" do
       image.set_from_gicon(gicon, :dialog)
+
       _(image.get_gicon).must_equal [gicon, 6]
     end
 
     it "works when called with an integer" do
       image.set_from_gicon(gicon, 4)
+
       _(image.get_gicon).must_equal [gicon, 4]
     end
   end

--- a/test/gir_ffi-gtk/list_store_test.rb
+++ b/test/gir_ffi-gtk/list_store_test.rb
@@ -6,6 +6,7 @@ describe Gtk::ListStore do
   describe ".new" do
     it "takes an array of column types" do
       store = Gtk::ListStore.new([GObject::TYPE_STRING, GObject::TYPE_INT])
+
       _(store).must_be_instance_of Gtk::ListStore
     end
   end
@@ -14,6 +15,7 @@ describe Gtk::ListStore do
     it "inserts a row with the given values" do
       store = Gtk::ListStore.new([GObject::TYPE_STRING, GObject::TYPE_INT])
       row = store.insert_with_values(0, [0, 1], ["foo", 42])
+
       _(store.get_value(row, 0)).must_equal "foo"
       _(store.get_value(row, 1)).must_equal 42
     end
@@ -24,6 +26,7 @@ describe Gtk::ListStore do
       store = Gtk::ListStore.new([GObject::TYPE_STRING, GObject::TYPE_INT])
       row = store.insert_with_values(0, [0, 1], ["foo", 42])
       store.set(row, [1, 0], [3, "bar"])
+
       _(store.get_value(row, 0)).must_equal "bar"
       _(store.get_value(row, 1)).must_equal 3
     end
@@ -34,6 +37,7 @@ describe Gtk::ListStore do
       store = Gtk::ListStore.new([GObject::TYPE_STRING, GObject::TYPE_INT])
       row = store.insert_with_values(0, [0, 1], ["foo", 42])
       store.set_value(row, 0, nil)
+
       _(store.get_value(row, 0)).must_be_nil
     end
   end

--- a/test/gir_ffi-gtk/message_dialog_test.rb
+++ b/test/gir_ffi-gtk/message_dialog_test.rb
@@ -6,11 +6,13 @@ describe Gtk::MessageDialog do
   describe ".new" do
     it "creates a Gtk::MessageDialog with the right text" do
       dialog = Gtk::MessageDialog.new nil, :modal, :info, :close, "Foo"
+
       _(dialog.text).must_equal "Foo"
     end
 
     it "handles all % characters in the message as literals" do
       dialog = Gtk::MessageDialog.new nil, :modal, :info, :close, "Foo %"
+
       _(dialog.text).must_equal "Foo %"
     end
   end

--- a/test/gir_ffi-gtk/radio_action_test.rb
+++ b/test/gir_ffi-gtk/radio_action_test.rb
@@ -7,6 +7,7 @@ describe Gtk::RadioAction do
     it "returns a GLib::SList object" do
       action = Gtk::RadioAction.new "name", "label", "tooltip", nil, 1
       grp = action.get_group
+
       _(grp).must_be_instance_of GLib::SList
     end
   end

--- a/test/gir_ffi-gtk/radio_button_test.rb
+++ b/test/gir_ffi-gtk/radio_button_test.rb
@@ -6,12 +6,14 @@ describe Gtk::RadioButton do
   describe ".new_from_widget" do
     it "works when called with nil" do
       result = Gtk::RadioButton.new_from_widget(nil)
+
       _(result).must_be_instance_of Gtk::RadioButton
     end
 
     it "works when called with another radio button" do
       btn = Gtk::RadioButton.new_from_widget nil
       result = Gtk::RadioButton.new_from_widget btn
+
       _(result).must_be_instance_of Gtk::RadioButton
     end
   end
@@ -28,12 +30,14 @@ describe Gtk::RadioButton do
   describe ".new" do
     it "works when called with nil" do
       result = Gtk::RadioButton.new nil
+
       _(result).must_be_instance_of Gtk::RadioButton
     end
 
     it "works when called with the result of #get_group" do
       btn = Gtk::RadioButton.new_from_widget nil
       result = Gtk::RadioButton.new btn.get_group
+
       _(result).must_be_instance_of Gtk::RadioButton
     end
   end

--- a/test/gir_ffi-gtk/target_entry_test.rb
+++ b/test/gir_ffi-gtk/target_entry_test.rb
@@ -6,6 +6,7 @@ describe Gtk::TargetEntry do
   describe ".new" do
     it "takes and uses three arguments" do
       entry = Gtk::TargetEntry.new("foo", 3, 42)
+
       _(entry.target).must_equal "foo"
       _(entry.flags).must_equal 3
       _(entry.info).must_equal 42
@@ -13,6 +14,7 @@ describe Gtk::TargetEntry do
 
     it "allows symbol values for the second argument" do
       entry = Gtk::TargetEntry.new("foo", :same_app, 42)
+
       _(entry.target).must_equal "foo"
       _(entry.flags).must_equal 1
       _(entry.info).must_equal 42

--- a/test/gir_ffi-gtk/tree_path_test.rb
+++ b/test/gir_ffi-gtk/tree_path_test.rb
@@ -6,6 +6,7 @@ describe Gtk::TreePath do
   describe "#get_indices" do
     it "returns an enumerable of the TreePath's indices" do
       tree_path = Gtk::TreePath.new_from_string "1:2:3"
+
       _(tree_path.get_indices.to_a).must_equal [1, 2, 3]
     end
   end
@@ -13,6 +14,7 @@ describe Gtk::TreePath do
   describe ".new_from_indices" do
     it "creates a Gtk::TreePath with the right indices" do
       tree_path = Gtk::TreePath.new_from_indices [1, 2, 3]
+
       _(tree_path.get_indices.to_a).must_equal [1, 2, 3]
     end
   end

--- a/test/gir_ffi-gtk/tree_store_test.rb
+++ b/test/gir_ffi-gtk/tree_store_test.rb
@@ -6,6 +6,7 @@ describe Gtk::TreeStore do
   describe ".new" do
     it "takes an array of column types" do
       store = Gtk::TreeStore.new([GObject::TYPE_STRING, GObject::TYPE_INT])
+
       _(store).must_be_instance_of Gtk::TreeStore
     end
   end
@@ -14,6 +15,7 @@ describe Gtk::TreeStore do
     it "inserts a row with the given values" do
       store = Gtk::TreeStore.new([GObject::TYPE_STRING, GObject::TYPE_INT])
       row = store.insert_with_values(nil, 0, [0, 1], ["foo", 42])
+
       _(store.get_value(row, 0)).must_equal "foo"
       _(store.get_value(row, 1)).must_equal 42
     end
@@ -24,6 +26,7 @@ describe Gtk::TreeStore do
       store = Gtk::TreeStore.new([GObject::TYPE_STRING, GObject::TYPE_INT])
       row = store.insert_with_values(nil, 0, [0, 1], ["foo", 42])
       store.set(row, [1, 0], [3, "bar"])
+
       _(store.get_value(row, 0)).must_equal "bar"
       _(store.get_value(row, 1)).must_equal 3
     end
@@ -34,6 +37,7 @@ describe Gtk::TreeStore do
       store = Gtk::TreeStore.new([GObject::TYPE_STRING, GObject::TYPE_INT])
       row = store.insert_with_values(nil, 0, [0, 1], ["foo", 42])
       store.set_value(row, 0, nil)
+
       _(store.get_value(row, 0)).must_be_nil
     end
   end

--- a/test/gir_ffi-gtk/tree_view_column_test.rb
+++ b/test/gir_ffi-gtk/tree_view_column_test.rb
@@ -24,11 +24,13 @@ describe Gtk::TreeViewColumn do
       row = list_store.append
       list_store.set_value(row, 1, "foo-value")
       column.cell_set_cell_data(list_store, row, false, false)
+
       _(renderer.text).must_equal "foo-value"
     end
 
     it "allows not specifying any attributes" do
       col = Gtk::TreeViewColumn.new_with_attributes("foo-title", renderer)
+
       _(col).must_be_instance_of Gtk::TreeViewColumn
     end
   end
@@ -47,6 +49,7 @@ describe Gtk::TreeViewColumn do
       row = list_store.append
       list_store.set_value(row, 1, "foo-value")
       column.cell_set_cell_data(list_store, row, false, false)
+
       _(renderer.text).must_equal "foo-value"
     end
   end

--- a/test/gir_ffi-gtk/widget_test.rb
+++ b/test/gir_ffi-gtk/widget_test.rb
@@ -18,12 +18,14 @@ describe Gtk::Widget do
     it "works when called with a bitmask hash" do
       widget.add_events button_press_mask: true
       ev = widget.get_events
+
       _(Gdk::EventMask.to_int(ev)).must_equal expected_native
     end
 
     it "works when called with a symbol" do
       widget.add_events :button_press_mask
       ev = widget.get_events
+
       _(Gdk::EventMask.to_int(ev)).must_equal expected_native
     end
 
@@ -31,6 +33,7 @@ describe Gtk::Widget do
       ev_int = Gdk::EventMask.to_int :button_press_mask
       widget.add_events ev_int
       ev = widget.get_events
+
       _(Gdk::EventMask.to_int(ev)).must_equal expected_native
     end
   end
@@ -41,6 +44,7 @@ describe Gtk::Widget do
     it "returns a bitmap hash" do
       widget.set_events focus_change_mask: true
       ev = widget.get_events
+
       _(ev).must_equal focus_change_mask: true
     end
   end
@@ -52,12 +56,14 @@ describe Gtk::Widget do
     it "works when called with a bitmask hash" do
       widget.set_events focus_change_mask: true
       ev = widget.get_events
+
       _(Gdk::EventMask.to_int(ev)).must_equal expected_native
     end
 
     it "works when called with a symbol" do
       widget.set_events :focus_change_mask
       ev = widget.get_events
+
       _(Gdk::EventMask.to_int(ev)).must_equal expected_native
     end
 
@@ -65,6 +71,7 @@ describe Gtk::Widget do
       ev_int = Gdk::EventMask.to_int :focus_change_mask
       widget.set_events ev_int
       ev = widget.get_events
+
       _(Gdk::EventMask.to_int(ev)).must_equal expected_native
     end
   end
@@ -75,6 +82,7 @@ describe Gtk::Widget do
     it "returns a bitmap hash" do
       widget.set_events focus_change_mask: true
       ev = widget.events
+
       _(ev).must_equal focus_change_mask: true
     end
   end
@@ -86,12 +94,14 @@ describe Gtk::Widget do
     it "works when called with a bitmask hash" do
       widget.events = { focus_change_mask: true }
       ev = widget.get_events
+
       _(Gdk::EventMask.to_int(ev)).must_equal expected_native
     end
 
     it "works when called with a symbol" do
       widget.events = :focus_change_mask
       ev = widget.get_events
+
       _(Gdk::EventMask.to_int(ev)).must_equal expected_native
     end
 
@@ -99,6 +109,7 @@ describe Gtk::Widget do
       ev_int = Gdk::EventMask.to_int :focus_change_mask
       widget.events = ev_int
       ev = widget.get_events
+
       _(Gdk::EventMask.to_int(ev)).must_equal expected_native
     end
   end


### PR DESCRIPTION
- Bump rubocop dependencies
- Use the new rubocop plugins configuration syntax
- Autocorrect Minitest/EmptyLineBeforeAssertionMethods
- Silence Naming/PredicateMethod offense
