### PR TITLE
Support Ruby 3.2 and above

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -20,7 +20,7 @@ jobs:
 
     strategy:
       matrix:
-        ruby: ["3.1", "3.2", "3.3", "3.4"]
+        ruby: ["3.2", "3.3", "3.4"]
 
     steps:
       - uses: actions/checkout@v4
@@ -58,7 +58,7 @@ jobs:
       - name: Set up Ruby
         uses: ruby/setup-ruby@v1
         with:
-          ruby-version: "3.2"
+          ruby-version: "3.3"
           bundler-cache: true
       - name: Run RuboCop
         run: bundle exec rubocop -P

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -10,7 +10,7 @@ plugins:
 
 AllCops:
   NewCops: enable
-  TargetRubyVersion: 3.1
+  TargetRubyVersion: 3.2
 
 # Put development dependencies in the gemspec so rubygems.org knows about them
 Gemspec/DevelopmentDependencies:

--- a/gir_ffi-gtk.gemspec
+++ b/gir_ffi-gtk.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |spec|
   spec.homepage = "http://www.github.com/mvz/gir_ffi-gtk"
 
   spec.license = "LGPL-2.1+"
-  spec.required_ruby_version = ">= 3.1.0"
+  spec.required_ruby_version = ">= 3.2.0"
 
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = "https://github.com/mvz/gir_ffi-gtk"

--- a/lib/gir_ffi-gtk/dialog.rb
+++ b/lib/gir_ffi-gtk/dialog.rb
@@ -13,9 +13,9 @@ module Gtk
 
   # Overrides for GtkDialog
   class Dialog
-    def self.new_with_buttons(*args)
+    def self.new_with_buttons(*)
       obj = allocate
-      obj.send :initialize_with_buttons, *args
+      obj.send(:initialize_with_buttons, *)
       obj
     end
 

--- a/lib/gir_ffi-gtk/file_chooser_dialog.rb
+++ b/lib/gir_ffi-gtk/file_chooser_dialog.rb
@@ -13,9 +13,9 @@ module Gtk
 
   # Overrides for GtkFileChooserDialog
   class FileChooserDialog
-    def self.new(*args)
+    def self.new(*)
       obj = allocate
-      obj.send :initialize, *args
+      obj.send(:initialize, *)
       obj
     end
 

--- a/lib/gir_ffi-gtk/gtk2/radio_button.rb
+++ b/lib/gir_ffi-gtk/gtk2/radio_button.rb
@@ -10,9 +10,9 @@ module Gtk
 
   # Overrides for GtkRadioButton
   class RadioButton
-    def self.new_from_widget(*args)
+    def self.new_from_widget(*)
       obj = allocate
-      obj.send :initialize_from_widget, *args
+      obj.send(:initialize_from_widget, *)
       obj
     end
 

--- a/lib/gir_ffi-gtk/tree_path.rb
+++ b/lib/gir_ffi-gtk/tree_path.rb
@@ -9,9 +9,9 @@ module Gtk
 
   # Overrides for GtkTreePath
   class TreePath
-    def self.new_from_indices(*args)
+    def self.new_from_indices(*)
       obj = allocate
-      obj.send :initialize_from_indices, *args
+      obj.send(:initialize_from_indices, *)
       obj
     end
 

--- a/lib/gir_ffi-gtk/tree_view_column.rb
+++ b/lib/gir_ffi-gtk/tree_view_column.rb
@@ -6,9 +6,9 @@ module Gtk
   class TreeViewColumn
     setup_method! :new
 
-    def self.new_with_attributes(*args)
+    def self.new_with_attributes(*)
       obj = allocate
-      obj.send :initialize_with_attributes, *args
+      obj.send(:initialize_with_attributes, *)
       obj
     end
 


### PR DESCRIPTION
- **Require Ruby 3.2 or higher**
- **Bump RuboCop target ruby version**
- **Autocorrect Style/ArgumentsForwarding**
- **Remove Ruby 3.1 from the CI matrix**
