### PR TITLE
Bump rubocop dependency versions and fix new offense

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -12,10 +12,6 @@ AllCops:
   NewCops: enable
   TargetRubyVersion: 3.2
 
-# Put development dependencies in the gemspec so rubygems.org knows about them
-Gemspec/DevelopmentDependencies:
-  EnforcedStyle: gemspec
-
 # Make BeginEndAlignment behavior match EndAlignment
 Layout/BeginEndAlignment:
   EnforcedStyleAlignWith: begin

--- a/Gemfile
+++ b/Gemfile
@@ -2,5 +2,18 @@
 
 source "https://rubygems.org"
 
-# The gem's dependencies are specified in gir_ffi.gemspec
+# The gem's dependencies are specified in gir_ffi-gtk.gemspec
 gemspec
+
+group :development do
+  gem "minitest", "~> 6.0"
+  gem "minitest-focus", "~> 1.4"
+  gem "rake", "~> 13.0"
+  gem "rake-manifest", "~> 0.2.0"
+  gem "rubocop", "~> 1.76"
+  gem "rubocop-minitest", "~> 0.38.0"
+  gem "rubocop-packaging", "~> 0.6.0"
+  gem "rubocop-performance", "~> 1.25"
+  gem "rubocop-rake", "~> 0.7.1"
+  gem "simplecov", "~> 0.22.0"
+end

--- a/Gemfile
+++ b/Gemfile
@@ -10,10 +10,10 @@ group :development do
   gem "minitest-focus", "~> 1.4"
   gem "rake", "~> 13.0"
   gem "rake-manifest", "~> 0.2.0"
-  gem "rubocop", "~> 1.76"
-  gem "rubocop-minitest", "~> 0.38.0"
+  gem "rubocop", "~> 1.85"
+  gem "rubocop-minitest", "~> 0.39.1"
   gem "rubocop-packaging", "~> 0.6.0"
-  gem "rubocop-performance", "~> 1.25"
+  gem "rubocop-performance", "~> 1.26"
   gem "rubocop-rake", "~> 0.7.1"
   gem "simplecov", "~> 0.22.0"
 end

--- a/gir_ffi-gtk.gemspec
+++ b/gir_ffi-gtk.gemspec
@@ -24,15 +24,4 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "gir_ffi", "~> 0.18.0"
-
-  spec.add_development_dependency "minitest", "~> 6.0"
-  spec.add_development_dependency "minitest-focus", "~> 1.4"
-  spec.add_development_dependency "rake", "~> 13.0"
-  spec.add_development_dependency "rake-manifest", "~> 0.2.0"
-  spec.add_development_dependency "rubocop", "~> 1.76"
-  spec.add_development_dependency "rubocop-minitest", "~> 0.38.0"
-  spec.add_development_dependency "rubocop-packaging", "~> 0.6.0"
-  spec.add_development_dependency "rubocop-performance", "~> 1.25"
-  spec.add_development_dependency "rubocop-rake", "~> 0.7.1"
-  spec.add_development_dependency "simplecov", "~> 0.22.0"
 end

--- a/lib/gir_ffi-gtk/base.rb
+++ b/lib/gir_ffi-gtk/base.rb
@@ -57,7 +57,7 @@ module GirFFIGtk
 end
 
 # Overrides for Gtk module functions
-module Gtk
+Gtk.module_eval do
   setup_method! "init"
   setup_method! "main"
 


### PR DESCRIPTION
- **Move development dependencies to the Gemfile**
- **Bump rubocop dependency versions**
- **Fix Style/OneClassPerFile offense**
